### PR TITLE
Fix blinking last dot

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -178,8 +178,8 @@ static void draw_seconds_bar(int seconds, uint8_t r, uint8_t g, uint8_t b) {
     int x = i;
     int index = xy_to_index(x, MATRIX_HEIGHT - 1) * 3;
     bool on = i < tick;
-    if (blink_last_dot && i == MATRIX_WIDTH - 1 && (seconds % 2 == 0)) {
-      on = false;
+    if (blink_last_dot && i == MATRIX_WIDTH - 1 && tick == MATRIX_WIDTH - 1) {
+      on = (seconds % 2) != 0;
     }
     if (on) {
       led_data[index] = adj_g;


### PR DESCRIPTION
## Summary
- update `draw_seconds_bar` logic so the last segment can blink

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6848234dc8fc832ba414398b21cb7b15